### PR TITLE
[#35] Use `LitePullConsumer` model instead of default pull consumer

### DIFF
--- a/src/main/java/org/apache/rocketmq/flink/common/RocketMQOptions.java
+++ b/src/main/java/org/apache/rocketmq/flink/common/RocketMQOptions.java
@@ -64,6 +64,9 @@ public class RocketMQOptions {
     public static final ConfigOption<Long> OPTIONAL_PARTITION_DISCOVERY_INTERVAL_MS =
             ConfigOptions.key("partitionDiscoveryIntervalMs").longType().defaultValue(30000L);
 
+    public static final ConfigOption<Integer> OPTIONAL_CONSUMER_POLL_MS =
+            ConfigOptions.key("consumer.timeout").intType().defaultValue(3000);
+
     public static final ConfigOption<Boolean> OPTIONAL_USE_NEW_API =
             ConfigOptions.key("useNewApi").booleanType().defaultValue(true);
 

--- a/src/main/java/org/apache/rocketmq/flink/common/RocketMQOptions.java
+++ b/src/main/java/org/apache/rocketmq/flink/common/RocketMQOptions.java
@@ -64,8 +64,8 @@ public class RocketMQOptions {
     public static final ConfigOption<Long> OPTIONAL_PARTITION_DISCOVERY_INTERVAL_MS =
             ConfigOptions.key("partitionDiscoveryIntervalMs").longType().defaultValue(30000L);
 
-    public static final ConfigOption<Integer> OPTIONAL_CONSUMER_POLL_MS =
-            ConfigOptions.key("consumer.timeout").intType().defaultValue(3000);
+    public static final ConfigOption<Long> OPTIONAL_CONSUMER_POLL_MS =
+            ConfigOptions.key("consumer.timeout").longType().defaultValue(3000L);
 
     public static final ConfigOption<Boolean> OPTIONAL_USE_NEW_API =
             ConfigOptions.key("useNewApi").booleanType().defaultValue(true);

--- a/src/main/java/org/apache/rocketmq/flink/legacy/RocketMQConfig.java
+++ b/src/main/java/org/apache/rocketmq/flink/legacy/RocketMQConfig.java
@@ -20,7 +20,7 @@ import org.apache.rocketmq.acl.common.AclClientRPCHook;
 import org.apache.rocketmq.acl.common.SessionCredentials;
 import org.apache.rocketmq.client.AccessChannel;
 import org.apache.rocketmq.client.ClientConfig;
-import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
 import org.apache.rocketmq.common.protocol.heartbeat.MessageModel;
 
@@ -59,7 +59,11 @@ public class RocketMQConfig {
     public static final int DEFAULT_PRODUCER_RETRY_TIMES = 3;
 
     public static final String PRODUCER_TIMEOUT = "producer.timeout";
+
+    public static final String CONSUMER_TIMEOUT = "consumer.timeout";
     public static final int DEFAULT_PRODUCER_TIMEOUT = 3000; // 3 seconds
+
+    public static final int DEFAULT_CONSUMER_TIMEOUT = 3000; // 3 seconds
 
     // Consumer related config
     public static final String CONSUMER_GROUP = "consumer.group"; // Required
@@ -142,9 +146,9 @@ public class RocketMQConfig {
      * Build Consumer Configs.
      *
      * @param props Properties
-     * @param consumer DefaultMQPullConsumer
+     * @param consumer DefaultLitePullConsumer
      */
-    public static void buildConsumerConfigs(Properties props, DefaultMQPullConsumer consumer) {
+    public static void buildConsumerConfigs(Properties props, DefaultLitePullConsumer consumer) {
         buildCommonConfigs(props, consumer);
         consumer.setMessageModel(MessageModel.CLUSTERING);
         consumer.setPersistConsumerOffsetInterval(

--- a/src/main/java/org/apache/rocketmq/flink/source/RocketMQSource.java
+++ b/src/main/java/org/apache/rocketmq/flink/source/RocketMQSource.java
@@ -60,7 +60,7 @@ public class RocketMQSource<OUT>
 
     private final String consumerOffsetMode;
     private final long consumerOffsetTimestamp;
-    private final int pollTime;
+    private final long pollTime;
     private final String topic;
     private final String consumerGroup;
     private final String nameServerAddress;
@@ -80,7 +80,7 @@ public class RocketMQSource<OUT>
     private final RocketMQDeserializationSchema<OUT> deserializationSchema;
 
     public RocketMQSource(
-            int pollTime,
+            long pollTime,
             String topic,
             String consumerGroup,
             String nameServerAddress,

--- a/src/main/java/org/apache/rocketmq/flink/source/RocketMQSource.java
+++ b/src/main/java/org/apache/rocketmq/flink/source/RocketMQSource.java
@@ -60,6 +60,7 @@ public class RocketMQSource<OUT>
 
     private final String consumerOffsetMode;
     private final long consumerOffsetTimestamp;
+    private final int pollTime;
     private final String topic;
     private final String consumerGroup;
     private final String nameServerAddress;
@@ -79,6 +80,7 @@ public class RocketMQSource<OUT>
     private final RocketMQDeserializationSchema<OUT> deserializationSchema;
 
     public RocketMQSource(
+            int pollTime,
             String topic,
             String consumerGroup,
             String nameServerAddress,
@@ -97,6 +99,7 @@ public class RocketMQSource<OUT>
         Validate.isTrue(
                 !(StringUtils.isNotEmpty(tag) && StringUtils.isNotEmpty(sql)),
                 "Consumer tag and sql can not set value at the same time");
+        this.pollTime = pollTime;
         this.topic = topic;
         this.consumerGroup = consumerGroup;
         this.nameServerAddress = nameServerAddress;
@@ -140,6 +143,7 @@ public class RocketMQSource<OUT>
         Supplier<SplitReader<Tuple3<OUT, Long, Long>, RocketMQPartitionSplit>> splitReaderSupplier =
                 () ->
                         new RocketMQPartitionSplitReader<>(
+                                pollTime,
                                 topic,
                                 consumerGroup,
                                 nameServerAddress,

--- a/src/main/java/org/apache/rocketmq/flink/source/reader/RocketMQPartitionSplitReader.java
+++ b/src/main/java/org/apache/rocketmq/flink/source/reader/RocketMQPartitionSplitReader.java
@@ -70,7 +70,7 @@ public class RocketMQPartitionSplitReader<T>
     private final long startTime;
     private final long startOffset;
 
-    private final int pollTime;
+    private final long pollTime;
 
     private final String accessKey;
     private final String secretKey;
@@ -87,7 +87,7 @@ public class RocketMQPartitionSplitReader<T>
     private static final int MAX_MESSAGE_NUMBER_PER_BLOCK = 64;
 
     public RocketMQPartitionSplitReader(
-            int pollTime,
+            long pollTime,
             String topic,
             String consumerGroup,
             String nameServerAddress,
@@ -122,11 +122,6 @@ public class RocketMQPartitionSplitReader<T>
         Collection<MessageQueue> messageQueues;
         try {
             messageQueues = consumer.fetchMessageQueues(topic);
-            if (StringUtils.isNotEmpty(sql)) {
-                consumer.subscribe(topic, MessageSelector.bySql(sql));
-            } else {
-                consumer.subscribe(topic, tag);
-            }
         } catch (MQClientException e) {
             LOG.error(
                     String.format(
@@ -177,7 +172,6 @@ public class RocketMQPartitionSplitReader<T>
                         recordsBySplits.prepareForRead();
                         return recordsBySplits;
                     }
-                    consumer.assign(Collections.singletonList(messageQueue));
 
                     consumer.setPullBatchSize(MAX_MESSAGE_NUMBER_PER_BLOCK);
                     consumer.seek(messageQueue, messageOffset);
@@ -337,6 +331,11 @@ public class RocketMQPartitionSplitReader<T>
                             consumerGroup,
                             "" + System.nanoTime()));
             consumer.start();
+            if (StringUtils.isNotEmpty(sql)) {
+                consumer.subscribe(topic, MessageSelector.bySql(sql));
+            } else {
+                consumer.subscribe(topic, tag);
+            }
         } catch (MQClientException e) {
             LOG.error("Failed to initial RocketMQ consumer.", e);
             consumer.shutdown();

--- a/src/main/java/org/apache/rocketmq/flink/source/table/RocketMQDynamicTableSourceFactory.java
+++ b/src/main/java/org/apache/rocketmq/flink/source/table/RocketMQDynamicTableSourceFactory.java
@@ -184,7 +184,7 @@ public class RocketMQDynamicTableSourceFactory implements DynamicTableSourceFact
                 configuration.getLong(
                         RocketMQOptions.OPTIONAL_OFFSET_FROM_TIMESTAMP, System.currentTimeMillis());
         return new RocketMQScanTableSource(
-                configuration.getInteger(OPTIONAL_CONSUMER_POLL_MS),
+                configuration.getLong(OPTIONAL_CONSUMER_POLL_MS),
                 descriptorProperties,
                 physicalSchema,
                 topic,

--- a/src/main/java/org/apache/rocketmq/flink/source/table/RocketMQDynamicTableSourceFactory.java
+++ b/src/main/java/org/apache/rocketmq/flink/source/table/RocketMQDynamicTableSourceFactory.java
@@ -44,6 +44,7 @@ import static org.apache.rocketmq.flink.common.RocketMQOptions.CONSUMER_GROUP;
 import static org.apache.rocketmq.flink.common.RocketMQOptions.NAME_SERVER_ADDRESS;
 import static org.apache.rocketmq.flink.common.RocketMQOptions.OPTIONAL_ACCESS_KEY;
 import static org.apache.rocketmq.flink.common.RocketMQOptions.OPTIONAL_COLUMN_ERROR_DEBUG;
+import static org.apache.rocketmq.flink.common.RocketMQOptions.OPTIONAL_CONSUMER_POLL_MS;
 import static org.apache.rocketmq.flink.common.RocketMQOptions.OPTIONAL_ENCODING;
 import static org.apache.rocketmq.flink.common.RocketMQOptions.OPTIONAL_END_TIME;
 import static org.apache.rocketmq.flink.common.RocketMQOptions.OPTIONAL_FIELD_DELIMITER;
@@ -104,6 +105,7 @@ public class RocketMQDynamicTableSourceFactory implements DynamicTableSourceFact
         optionalOptions.add(OPTIONAL_ACCESS_KEY);
         optionalOptions.add(OPTIONAL_SECRET_KEY);
         optionalOptions.add(OPTIONAL_SCAN_STARTUP_MODE);
+        optionalOptions.add(OPTIONAL_CONSUMER_POLL_MS);
         return optionalOptions;
     }
 
@@ -182,6 +184,7 @@ public class RocketMQDynamicTableSourceFactory implements DynamicTableSourceFact
                 configuration.getLong(
                         RocketMQOptions.OPTIONAL_OFFSET_FROM_TIMESTAMP, System.currentTimeMillis());
         return new RocketMQScanTableSource(
+                configuration.getInteger(OPTIONAL_CONSUMER_POLL_MS),
                 descriptorProperties,
                 physicalSchema,
                 topic,

--- a/src/main/java/org/apache/rocketmq/flink/source/table/RocketMQScanTableSource.java
+++ b/src/main/java/org/apache/rocketmq/flink/source/table/RocketMQScanTableSource.java
@@ -73,10 +73,12 @@ public class RocketMQScanTableSource implements ScanTableSource, SupportsReading
     private final long startMessageOffset;
     private final long startTime;
     private final boolean useNewApi;
+    private final int pollTime;
 
     private List<String> metadataKeys;
 
     public RocketMQScanTableSource(
+            int pollTime,
             DescriptorProperties properties,
             TableSchema schema,
             String topic,
@@ -93,6 +95,7 @@ public class RocketMQScanTableSource implements ScanTableSource, SupportsReading
             String consumerOffsetMode,
             long consumerOffsetTimestamp,
             boolean useNewApi) {
+        this.pollTime = pollTime;
         this.properties = properties;
         this.schema = schema;
         this.topic = topic;
@@ -122,6 +125,7 @@ public class RocketMQScanTableSource implements ScanTableSource, SupportsReading
         if (useNewApi) {
             return SourceProvider.of(
                     new RocketMQSource<>(
+                            pollTime,
                             topic,
                             consumerGroup,
                             nameServerAddress,
@@ -162,6 +166,7 @@ public class RocketMQScanTableSource implements ScanTableSource, SupportsReading
     public DynamicTableSource copy() {
         RocketMQScanTableSource tableSource =
                 new RocketMQScanTableSource(
+                        pollTime,
                         properties,
                         schema,
                         topic,

--- a/src/main/java/org/apache/rocketmq/flink/source/table/RocketMQScanTableSource.java
+++ b/src/main/java/org/apache/rocketmq/flink/source/table/RocketMQScanTableSource.java
@@ -73,12 +73,12 @@ public class RocketMQScanTableSource implements ScanTableSource, SupportsReading
     private final long startMessageOffset;
     private final long startTime;
     private final boolean useNewApi;
-    private final int pollTime;
+    private final long pollTime;
 
     private List<String> metadataKeys;
 
     public RocketMQScanTableSource(
-            int pollTime,
+            long pollTime,
             DescriptorProperties properties,
             TableSchema schema,
             String topic,


### PR DESCRIPTION
close #35 
Use `DefaultLitePullConsumer` model instead of default pull consumer.

Tips
Thank you very much for contributing to Apache rocketmq-flink.
What is the purpose of the pull request
*solve some code about using defaultPullConsumer api

Brief change log
(for example:)

*Modify 
RocketMQConfig.java
RocketMQSourceFunction.java
RocketMQSourceEnumerator.java
RocketMQPartitionSplitReader.java
RocketMQSourceTest.java