### PR TITLE
[ISSUE #88] Introduce format parameter configuration to support different serialization and deserialization formats provided by Flink

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,23 +134,11 @@
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-broker</artifactId>
             <version>${rocketmq.version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>guava</artifactId>
-                    <groupId>com.google.guava</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-test</artifactId>
             <version>${rocketmq.version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>guava</artifactId>
-                    <groupId>com.google.guava</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.rocketmq</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,21 @@
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.apache.flink/flink-connector-files -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-files</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-json</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-clients</artifactId>
@@ -119,11 +134,23 @@
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-broker</artifactId>
             <version>${rocketmq.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>guava</artifactId>
+                    <groupId>com.google.guava</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-test</artifactId>
             <version>${rocketmq.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>guava</artifactId>
+                    <groupId>com.google.guava</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.rocketmq</groupId>

--- a/src/main/java/org/apache/rocketmq/flink/common/RocketMQOptions.java
+++ b/src/main/java/org/apache/rocketmq/flink/common/RocketMQOptions.java
@@ -20,7 +20,11 @@ package org.apache.rocketmq.flink.common;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.description.Description;
 
+import java.util.List;
+
+import static org.apache.flink.table.factories.FactoryUtil.FORMAT_SUFFIX;
 import static org.apache.rocketmq.flink.legacy.RocketMQConfig.DEFAULT_START_MESSAGE_OFFSET;
 
 /** Includes config options of RocketMQ connector type. */
@@ -117,4 +121,83 @@ public class RocketMQOptions {
 
     public static final ConfigOption<Long> OPTIONAL_OFFSET_FROM_TIMESTAMP =
             ConfigOptions.key("offsetFromTimestamp").longType().noDefaultValue();
+
+    // --------------------------------------------------------------------------------------------
+    // Format options
+    // --------------------------------------------------------------------------------------------
+
+    public static final ConfigOption<String> VALUE_FORMAT =
+            ConfigOptions.key("value" + FORMAT_SUFFIX)
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Defines the format identifier for encoding value data. "
+                                    + "The identifier is used to discover a suitable format factory.");
+
+    public static final ConfigOption<String> KEY_FORMAT =
+            ConfigOptions.key("key" + FORMAT_SUFFIX)
+                    .stringType()
+                    // .defaultValue("rocketmq-default")
+                    .noDefaultValue()
+                    .withDescription(
+                            "Defines the format identifier for encoding key data. "
+                                    + "The identifier is used to discover a suitable format factory.");
+
+    public static final ConfigOption<List<String>> KEY_FIELDS =
+            ConfigOptions.key("key.fields")
+                    .stringType()
+                    .asList()
+                    .defaultValues()
+                    .withDescription(
+                            "Defines an explicit list of physical columns from the table schema "
+                                    + "that configure the data type for the key format. By default, this list is "
+                                    + "empty and thus a key is undefined.");
+
+    public static final ConfigOption<ValueFieldsStrategy> VALUE_FIELDS_INCLUDE =
+            ConfigOptions.key("value.fields-include")
+                    .enumType(ValueFieldsStrategy.class)
+                    .defaultValue(ValueFieldsStrategy.ALL)
+                    .withDescription(
+                            String.format(
+                                    "Defines a strategy how to deal with key columns in the data type "
+                                            + "of the value format. By default, '%s' physical columns of the table schema "
+                                            + "will be included in the value format which means that the key columns "
+                                            + "appear in the data type for both the key and value format.",
+                                    ValueFieldsStrategy.ALL));
+
+    public static final ConfigOption<String> KEY_FIELDS_PREFIX =
+            ConfigOptions.key("key.fields-prefix")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Defines a custom prefix for all fields of the key format to avoid "
+                                                    + "name clashes with fields of the value format. "
+                                                    + "By default, the prefix is empty.")
+                                    .linebreak()
+                                    .text(
+                                            String.format(
+                                                    "If a custom prefix is defined, both the table schema and '%s' will work with prefixed names.",
+                                                    KEY_FIELDS.key()))
+                                    .linebreak()
+                                    .text(
+                                            "When constructing the data type of the key format, the prefix "
+                                                    + "will be removed and the non-prefixed names will be used within the key format.")
+                                    .linebreak()
+                                    .text(
+                                            String.format(
+                                                    "Please note that this option requires that '%s' must be '%s'.",
+                                                    VALUE_FIELDS_INCLUDE.key(),
+                                                    ValueFieldsStrategy.EXCEPT_KEY))
+                                    .build());
+
+    // --------------------------------------------------------------------------------------------
+    // Enums
+    // --------------------------------------------------------------------------------------------
+
+    public enum ValueFieldsStrategy {
+        ALL,
+        EXCEPT_KEY
+    }
 }

--- a/src/main/java/org/apache/rocketmq/flink/legacy/common/serialization/SimpleKeyValueDeserializationSchema.java
+++ b/src/main/java/org/apache/rocketmq/flink/legacy/common/serialization/SimpleKeyValueDeserializationSchema.java
@@ -17,13 +17,14 @@
 package org.apache.rocketmq.flink.legacy.common.serialization;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.MapTypeInfo;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.flink.api.java.typeutils.MapTypeInfo;
 
-public class SimpleKeyValueDeserializationSchema implements KeyValueDeserializationSchema<Map<String, String>> {
+public class SimpleKeyValueDeserializationSchema
+        implements KeyValueDeserializationSchema<Map<String, String>> {
     public static final String DEFAULT_KEY_FIELD = "key";
     public static final String DEFAULT_VALUE_FIELD = "value";
 

--- a/src/main/java/org/apache/rocketmq/flink/source/RocketMQSource.java
+++ b/src/main/java/org/apache/rocketmq/flink/source/RocketMQSource.java
@@ -29,7 +29,6 @@ import org.apache.rocketmq.flink.source.reader.deserializer.RocketMQDeserializat
 import org.apache.rocketmq.flink.source.split.RocketMQPartitionSplit;
 import org.apache.rocketmq.flink.source.split.RocketMQPartitionSplitSerializer;
 
-import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
@@ -123,12 +122,13 @@ public class RocketMQSource<OUT>
     }
 
     @Override
-    public SourceReader<OUT, RocketMQPartitionSplit> createReader(
-            SourceReaderContext readerContext) {
+    public SourceReader<OUT, RocketMQPartitionSplit> createReader(SourceReaderContext readerContext)
+            throws Exception {
         FutureCompletingBlockingQueue<RecordsWithSplitIds<Tuple3<OUT, Long, Long>>> elementsQueue =
                 new FutureCompletingBlockingQueue<>();
         deserializationSchema.open(
-                new DeserializationSchema.InitializationContext() {
+                new org.apache.flink.api.common.serialization.DeserializationSchema
+                        .InitializationContext() {
                     @Override
                     public MetricGroup getMetricGroup() {
                         return readerContext.metricGroup();

--- a/src/main/java/org/apache/rocketmq/flink/source/reader/deserializer/RocketMQDeserializationSchema.java
+++ b/src/main/java/org/apache/rocketmq/flink/source/reader/deserializer/RocketMQDeserializationSchema.java
@@ -42,7 +42,7 @@ public interface RocketMQDeserializationSchema<T>
      */
     @Override
     @PublicEvolving
-    default void open(InitializationContext context) {}
+    default void open(InitializationContext context) throws Exception {}
 
     /**
      * Deserializes the byte message.

--- a/src/main/java/org/apache/rocketmq/flink/source/table/RocketMQConnectorOptionsUtil.java
+++ b/src/main/java/org/apache/rocketmq/flink/source/table/RocketMQConnectorOptionsUtil.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.flink.source.table;
+
+import org.apache.rocketmq.flink.common.RocketMQOptions;
+import org.apache.rocketmq.flink.common.RocketMQOptions.ValueFieldsStrategy;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
+import org.apache.flink.util.Preconditions;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static org.apache.rocketmq.flink.common.RocketMQOptions.KEY_FIELDS;
+import static org.apache.rocketmq.flink.common.RocketMQOptions.KEY_FIELDS_PREFIX;
+import static org.apache.rocketmq.flink.common.RocketMQOptions.KEY_FORMAT;
+import static org.apache.rocketmq.flink.common.RocketMQOptions.VALUE_FIELDS_INCLUDE;
+
+/** Utilities for {@link RocketMQOptions}. */
+@Internal
+class RocketMQConnectorOptionsUtil {
+
+    /**
+     * Creates an array of indices that determine which physical fields of the table schema to
+     * include in the key format and the order that those fields have in the key format.
+     *
+     * <p>See {@link RocketMQOptions#KEY_FORMAT}, {@link RocketMQOptions#KEY_FIELDS}, and {@link
+     * RocketMQOptions#KEY_FIELDS_PREFIX} for more information.
+     */
+    public static int[] createKeyFormatProjection(
+            ReadableConfig options, DataType physicalDataType) {
+        final LogicalType physicalType = physicalDataType.getLogicalType();
+        Preconditions.checkArgument(
+                physicalType.is(LogicalTypeRoot.ROW), "Row data type expected.");
+        final Optional<String> optionalKeyFormat = options.getOptional(KEY_FORMAT);
+        final Optional<List<String>> optionalKeyFields = options.getOptional(KEY_FIELDS);
+
+        if (!optionalKeyFormat.isPresent() && optionalKeyFields.isPresent()) {
+            throw new ValidationException(
+                    String.format(
+                            "The option '%s' can only be declared if a key format is defined using '%s'.",
+                            KEY_FIELDS.key(), KEY_FORMAT.key()));
+        } else if (optionalKeyFormat.isPresent()
+                && (!optionalKeyFields.isPresent() || optionalKeyFields.get().size() == 0)) {
+            throw new ValidationException(
+                    String.format(
+                            "A key format '%s' requires the declaration of one or more of key fields using '%s'.",
+                            KEY_FORMAT.key(), KEY_FIELDS.key()));
+        }
+
+        if (!optionalKeyFormat.isPresent()) {
+            return new int[0];
+        }
+
+        final String keyPrefix = options.getOptional(KEY_FIELDS_PREFIX).orElse("");
+
+        final List<String> keyFields = optionalKeyFields.get();
+        final List<String> physicalFields = LogicalTypeChecks.getFieldNames(physicalType);
+        return keyFields.stream()
+                .mapToInt(
+                        keyField -> {
+                            final int pos = physicalFields.indexOf(keyField);
+                            // check that field name exists
+                            if (pos < 0) {
+                                throw new ValidationException(
+                                        String.format(
+                                                "Could not find the field '%s' in the table schema for usage in the key format. "
+                                                        + "A key field must be a regular, physical column. "
+                                                        + "The following columns can be selected in the '%s' option:\n"
+                                                        + "%s",
+                                                keyField, KEY_FIELDS.key(), physicalFields));
+                            }
+                            // check that field name is prefixed correctly
+                            if (!keyField.startsWith(keyPrefix)) {
+                                throw new ValidationException(
+                                        String.format(
+                                                "All fields in '%s' must be prefixed with '%s' when option '%s' "
+                                                        + "is set but field '%s' is not prefixed.",
+                                                KEY_FIELDS.key(),
+                                                keyPrefix,
+                                                KEY_FIELDS_PREFIX.key(),
+                                                keyField));
+                            }
+                            return pos;
+                        })
+                .toArray();
+    }
+    /**
+     * Creates an array of indices that determine which physical fields of the table schema to
+     * include in the value format.
+     *
+     * <p>See {@link RocketMQOptions#VALUE_FORMAT}, {@link RocketMQOptions#VALUE_FIELDS_INCLUDE},
+     * and {@link RocketMQOptions#KEY_FIELDS_PREFIX} for more information.
+     */
+    public static int[] createValueFormatProjection(
+            ReadableConfig options, DataType physicalDataType) {
+        final LogicalType physicalType = physicalDataType.getLogicalType();
+        Preconditions.checkArgument(
+                physicalType.is(LogicalTypeRoot.ROW), "Row data type expected.");
+        final int physicalFieldCount = LogicalTypeChecks.getFieldCount(physicalType);
+        final IntStream physicalFields = IntStream.range(0, physicalFieldCount);
+
+        final String keyPrefix = options.getOptional(KEY_FIELDS_PREFIX).orElse("");
+
+        final ValueFieldsStrategy strategy = options.get(VALUE_FIELDS_INCLUDE);
+        if (strategy == ValueFieldsStrategy.ALL) {
+            if (keyPrefix.length() > 0) {
+                throw new ValidationException(
+                        String.format(
+                                "A key prefix is not allowed when option '%s' is set to '%s'. "
+                                        + "Set it to '%s' instead to avoid field overlaps.",
+                                VALUE_FIELDS_INCLUDE.key(),
+                                ValueFieldsStrategy.ALL,
+                                ValueFieldsStrategy.EXCEPT_KEY));
+            }
+            return physicalFields.toArray();
+        } else if (strategy == ValueFieldsStrategy.EXCEPT_KEY) {
+            final int[] keyProjection = createKeyFormatProjection(options, physicalDataType);
+            return physicalFields
+                    .filter(pos -> IntStream.of(keyProjection).noneMatch(k -> k == pos))
+                    .toArray();
+        }
+        throw new TableException("Unknown value fields strategy:" + strategy);
+    }
+
+    private RocketMQConnectorOptionsUtil() {}
+}

--- a/src/test/java/org/apache/rocketmq/flink/legacy/RocketMQSourceTest.java
+++ b/src/test/java/org/apache/rocketmq/flink/legacy/RocketMQSourceTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.rocketmq.flink.legacy;
 
-import java.util.Map;
 import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
 import org.apache.rocketmq.client.consumer.PullResult;
 import org.apache.rocketmq.client.consumer.PullStatus;
@@ -36,6 +35,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/test/java/org/apache/rocketmq/flink/source/table/RocketMQDynamicTableSourceFactoryTest.java
+++ b/src/test/java/org/apache/rocketmq/flink/source/table/RocketMQDynamicTableSourceFactoryTest.java
@@ -56,6 +56,8 @@ public class RocketMQDynamicTableSourceFactoryTest {
     private static final String CONSUMER_GROUP = "test_consumer";
     private static final String NAME_SERVER_ADDRESS = "127.0.0.1:9876";
 
+    private static final String FORMAT_JSON = "json";
+
     @Test
     public void testRocketMQDynamicTableSourceWithLegalOption() {
         final Map<String, String> options = new HashMap<>();
@@ -64,6 +66,40 @@ public class RocketMQDynamicTableSourceFactoryTest {
         options.put(RocketMQOptions.CONSUMER_GROUP.key(), CONSUMER_GROUP);
         options.put(RocketMQOptions.NAME_SERVER_ADDRESS.key(), NAME_SERVER_ADDRESS);
         final DynamicTableSource tableSource = createTableSource(options);
+        assertTrue(tableSource instanceof RocketMQScanTableSource);
+        assertEquals(RocketMQScanTableSource.class.getName(), tableSource.asSummaryString());
+    }
+
+    @Test
+    public void testRocketMQDynamicTableSourceWithFormatOption() {
+        final Map<String, String> options = new HashMap<>();
+        options.put("connector", IDENTIFIER);
+        options.put(RocketMQOptions.TOPIC.key(), TOPIC);
+        options.put(RocketMQOptions.CONSUMER_GROUP.key(), CONSUMER_GROUP);
+        options.put(RocketMQOptions.NAME_SERVER_ADDRESS.key(), NAME_SERVER_ADDRESS);
+
+        options.put(FactoryUtil.FORMAT.key(), FORMAT_JSON);
+        final DynamicTableSource tableSource = createTableSource(options);
+
+        assertTrue(tableSource instanceof RocketMQScanTableSource);
+        assertEquals(RocketMQScanTableSource.class.getName(), tableSource.asSummaryString());
+    }
+
+    @Test
+    public void testRocketMQDynamicTableSourceWithJsonOption() {
+        final Map<String, String> options = new HashMap<>();
+        options.put("connector", IDENTIFIER);
+        options.put(RocketMQOptions.TOPIC.key(), TOPIC);
+        options.put(RocketMQOptions.CONSUMER_GROUP.key(), CONSUMER_GROUP);
+        options.put(RocketMQOptions.NAME_SERVER_ADDRESS.key(), NAME_SERVER_ADDRESS);
+        options.put(FactoryUtil.FORMAT.key(), FORMAT_JSON);
+
+        // json props
+        options.put("json.fail-on-missing-field", "false");
+        options.put("json.ignore-parse-errors", "true");
+        options.put("json.map-null-key.mode", "FAIL");
+        final DynamicTableSource tableSource = createTableSource(options);
+
         assertTrue(tableSource instanceof RocketMQScanTableSource);
         assertEquals(RocketMQScanTableSource.class.getName(), tableSource.asSummaryString());
     }


### PR DESCRIPTION
# Background
rocketmq-flink connector. Now the format only supports the default format, and cannot expand other formats.

This pr refers to the implementation of kafka, and expands the format to the format officially supported by flink
Such as JSON and csv etc.

# TODO
1. key deserialization