### PR TITLE
Make job fail instead of finished when consumes  exception when use l…

### DIFF
--- a/src/main/java/org/apache/flink/connector/rocketmq/legacy/RocketMQSourceFunction.java
+++ b/src/main/java/org/apache/flink/connector/rocketmq/legacy/RocketMQSourceFunction.java
@@ -358,8 +358,11 @@ public class RocketMQSourceFunction<OUT> extends RichParallelSourceFunction<OUT>
     }
 
     private void awaitTermination() throws InterruptedException {
-        while (runningChecker.isRunning()) {
+        while (runningChecker.isRunning() && runningChecker.getError()==null) {
             Thread.sleep(50);
+        }
+        if(runningChecker.getError()!=null){
+            throw new RuntimeException(runningChecker.getError());
         }
     }
 

--- a/src/main/java/org/apache/flink/connector/rocketmq/legacy/RunningChecker.java
+++ b/src/main/java/org/apache/flink/connector/rocketmq/legacy/RunningChecker.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 
 public class RunningChecker implements Serializable {
     private volatile boolean isRunning = false;
+    private volatile Throwable error;
 
     public boolean isRunning() {
         return isRunning;
@@ -28,4 +29,14 @@ public class RunningChecker implements Serializable {
     public void setRunning(boolean running) {
         isRunning = running;
     }
+
+    public void setError(Throwable e) {
+        this.error = e;
+    }
+
+    public Throwable getError() {
+        return this.error;
+    }
+
+
 }

--- a/src/main/java/org/apache/flink/connector/rocketmq/legacy/common/util/RetryUtil.java
+++ b/src/main/java/org/apache/flink/connector/rocketmq/legacy/common/util/RetryUtil.java
@@ -57,6 +57,7 @@ public class RetryUtil {
             } catch (Exception ex) {
                 if (retries >= MAX_ATTEMPTS) {
                     if (null != runningChecker) {
+                        runningChecker.setError(ex);
                         runningChecker.setRunning(false);
                     }
                     throw new RuntimeException(ex);


### PR DESCRIPTION
When use legacy source , we should catch and throw the exception in the source‘s main thread  ,so that flink can stop with failed status but not finished status 